### PR TITLE
Back key support on Android

### DIFF
--- a/source/backend/Controls.hx
+++ b/source/backend/Controls.hx
@@ -135,7 +135,7 @@ class Controls
 		return justPressed('accept');
 
 	private function get_BACK()
-		return justPressed('back');
+		return justPressed('back') #if android || FlxG.android.justReleased.BACK #end;
 
 	private function get_PAUSE()
 		return justPressed('pause');


### PR DESCRIPTION
Integrate the back key on the OS side with the back key on the PsychEngine side
In some cases it is useful